### PR TITLE
[fix] movies/views.py return_link, community/views.py transtime 함수 수정

### DIFF
--- a/community/views.py
+++ b/community/views.py
@@ -223,7 +223,7 @@ def transtime(year, month, day, hour, minute):
     # 월별 마지막 일
     monthday = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     # 윤달인 경우
-    if year % 4:
+    if (year % 4 == 0 and year % 100) or year % 400 == 0:
         monthday[2] = 29
     # 영국시간 => 한국시간
     hour += 9

--- a/movies/views.py
+++ b/movies/views.py
@@ -175,13 +175,17 @@ def return_link(title, date):
     soup = BeautifulSoup(html, "html.parser")
     try:
         search_link = soup.find("div", class_="title_area")
-        detail_link = search_link.find("a")["href"]
-        req2 = requests.get(detail_link)
-        html2 = req2.text
-        soup2 = BeautifulSoup(html2, "html.parser")
-        overview = soup2.find("p", class_="con_tx")
+        try:
+            detail_link = search_link.find("a")["href"]
+            req2 = requests.get(detail_link)
+            html2 = req2.text
+            soup2 = BeautifulSoup(html2, "html.parser")
+            overview = soup2.find("p", class_="con_tx")
+            return overview
+        except:
+            overview = ''
+            return overview
 
-        return overview
 
     except AttributeError as e:
         url = BASE_URL + title


### PR DESCRIPTION
1. [fix] movies/views.py return_link함수에서 줄거리가 없는 영화(주로 최신 영화)인 경우 줄거리가 없어 오류나는 것을 수정
2. [fix] community/views.py transtime함수에서 윤달 알고리즘 수정 (400년 기준 추가)